### PR TITLE
Lars/mty

### DIFF
--- a/PDP10/ka10_mty.c
+++ b/PDP10/ka10_mty.c
@@ -201,8 +201,6 @@ static t_stat mty_output_svc (UNIT *uptr)
     uint64 word;
     int i, ch;
 
-    tmxr_poll_tx (&mty_desc);
-
     for (i = 0; i < MTY_LINES; i++) {
         /* Round robin scan 32 lines. */
         scan = (scan + 1) & 037;
@@ -229,6 +227,7 @@ static t_stat mty_output_svc (UNIT *uptr)
         }
     }
 
+    tmxr_poll_tx (&mty_desc);
     if (mty_active_bitmask)
         //sim_activate_after (uptr, 1000000); TOO SLOW!
         sim_activate_after (uptr, 100);
@@ -278,6 +277,7 @@ static t_stat mty_attach (UNIT *uptr, CONST char *cptr)
         status = 0;
         sim_activate (uptr, tmxr_poll);
     }
+    mty_active_bitmask = 0;
     return stat;
 }
 


### PR DESCRIPTION
This should work better.

I didn't try to compare speed, but there was a key problem with the scanning logic, which I think is now fixed.  Specifically, the spurious interrupts were problematic and you really only want to do output scanning when the line's been enabled for output in the mty_active_bitmask, and you need to be able to process activities for more than one line on a single invocation of the output service routine, only pausing when an interrupt actually needs to be generated for a given line.